### PR TITLE
PDS lookup

### DIFF
--- a/harvardsettings_pi.php
+++ b/harvardsettings_pi.php
@@ -365,7 +365,7 @@ class Harvardsettings {
             $id = $person->univid;
             $return_obj->$id = (object) array(
                 'name' => $person->names[0]->firstName . " " . $person->names[0]->lastName,
-                'email' => $person->emails[0]->email
+                'email' => $person->loginName
             );    
         }
         log_message(

--- a/harvardsettings_pi.php
+++ b/harvardsettings_pi.php
@@ -352,7 +352,11 @@ class Harvardsettings {
                 'name' => $person->names[0]->firstName . " " . $person->names[0]->lastName,
                 'email' => $person->emails[0]->email
             );    
-        }   
+        }
+        log_message(
+            'info',
+            $this->CI->data['login']->email." accessed the PDS for this query: ".$url
+        );
         return $return_obj;    
     }
     

--- a/harvardsettings_pi.php
+++ b/harvardsettings_pi.php
@@ -201,19 +201,19 @@ class Harvardsettings {
           <div style="padding:1em;">
             <p><strong>Users Added: </strong>
                 <?
-                    $users_added = isset($_GET['users_added']) ? $_GET['users_added'] : 0;
+                    $users_added = isset($_GET['users_added']) ? htmlspecialchars($_GET['users_added']) : 0;
                     echo '<span>'.$users_added.'</span>';
                 ?>
             </p>
             <p><strong>New Accounts Created: </strong>
                 <?
-                    $new_accounts = isset($_GET['new_accounts_created']) ? $_GET['new_accounts_created'] : 0;
+                    $new_accounts = isset($_GET['new_accounts_created']) ? htmlspecialchars($_GET['new_accounts_created']) : 0;
                     echo '<span>'.$new_accounts.'</span>';
                 ?>
             <p>
             <p><strong>Failed to Add: </strong>
                 <?
-                    $unsuccessful = isset($_GET['unsuccessful']) ? $_GET['unsuccessful'] : 0;
+                    $unsuccessful = isset($_GET['unsuccessful']) ? htmlspecialchars($_GET['unsuccessful']) : 0;
                     echo '<span>'.$unsuccessful.'</span>';
                 ?>
             <p>
@@ -363,15 +363,21 @@ class Harvardsettings {
         }
         foreach($output as $person) {
             $id = $person->univid;
-            $name = !$person->privacyFerpaStatus ? $person->names[0]->firstName . " " . $person->names[0]->lastName : 'placeholder';
+            if ($person->privacyFerpaStatus) {
+                $name = 'placeholder';
+            }
+            else {
+                $name = $person->names[0]->firstName . " " . $person->names[0]->lastName;
+            }
             $return_obj->$id = (object) array(
                 'name' => $name,
                 'email' => $person->loginName
             );    
         }
+        $accessing_user = $this->CI->data['login']->email." (".$this->CI->data['login']->user_id.")";
         log_message(
             'info',
-            $this->CI->data['login']->email." accessed the PDS for this query: ".$url
+            $accessing_user." accessed the PDS for this query: ".$url
         );
         return $return_obj;    
     }

--- a/harvardsettings_pi.php
+++ b/harvardsettings_pi.php
@@ -72,7 +72,8 @@ class Harvardsettings {
                             'imported' => 1,
                             'message' => $processed['message'],
                             'users_added' => $processed['users_added'],
-                            'new_accounts_created' => $processed['new_accounts_created']
+                            'new_accounts_created' => $processed['new_accounts_created'],
+                            'unsuccessful' => $processed['unsuccessful']
                         );
                         $this->redirect_and_exit($redirect_params);
                     }
@@ -198,7 +199,7 @@ class Harvardsettings {
         
         <?php if($imported && $color === "saved"): ?>
           <div style="padding:1em;">
-            <p><strong>Users added: </strong>
+            <p><strong>Users Added: </strong>
                 <?
                     $users_added = isset($_GET['users_added']) ? $_GET['users_added'] : 0;
                     echo '<span>'.$users_added.'</span>';
@@ -208,6 +209,12 @@ class Harvardsettings {
                 <?
                     $new_accounts = isset($_GET['new_accounts_created']) ? $_GET['new_accounts_created'] : 0;
                     echo '<span>'.$new_accounts.'</span>';
+                ?>
+            <p>
+            <p><strong>Failed to Add: </strong>
+                <?
+                    $unsuccessful = isset($_GET['unsuccessful']) ? $_GET['unsuccessful'] : 0;
+                    echo '<span>'.$unsuccessful.'</span>';
                 ?>
             <p>
           </div>
@@ -266,6 +273,7 @@ class Harvardsettings {
         $message = "Book Users imported";
         $users_added = 0;
         $new_accounts_created = 0;
+        $unsuccessful = 0;
         
         // hit the PDS endpoint and get an user info only if necessary
         $curl_string = $this->build_curl_string($arr);
@@ -277,11 +285,17 @@ class Harvardsettings {
             $huid_row = trim($row['huid']);
             $name = trim($row['fullname']);
             $user = $this->get_scalar_user($email_row, $huid_row, $name, $unkown_emails);
-            if ($user === "no identifiers") {continue;}
+            if ($user === "no identifiers") {
+                $unsuccessful++;
+                continue;
+            }
             if (!$user) {
                 $user = $this->new_scalar_user($email_row, $name, $new_accounts_created);
             }
-            if (!$user) {continue;}
+            if (!$user) {
+                $unsuccessful++;
+                continue;
+            }
             
             $user_id = $user->user_id;
             $row_role = trim(strtolower($row['relationship']));
@@ -299,7 +313,8 @@ class Harvardsettings {
         return array(
             'message' => $message,
             'users_added' => $users_added,
-            'new_accounts_created' => $new_accounts_created
+            'new_accounts_created' => $new_accounts_created,
+            'unsuccessful' => $unsuccessful
         );
     }
     

--- a/harvardsettings_pi.php
+++ b/harvardsettings_pi.php
@@ -363,8 +363,9 @@ class Harvardsettings {
         }
         foreach($output as $person) {
             $id = $person->univid;
+            $name = !$person->privacyFerpaStatus ? $person->names[0]->firstName . " " . $person->names[0]->lastName : 'placeholder';
             $return_obj->$id = (object) array(
-                'name' => $person->names[0]->firstName . " " . $person->names[0]->lastName,
+                'name' => $name,
                 'email' => $person->loginName
             );    
         }

--- a/tests/HarvardsettingsTest.php
+++ b/tests/HarvardsettingsTest.php
@@ -2,7 +2,6 @@
 
 use PHPUnit\Framework\TestCase;
 
-
 function get_mock_codeigniter_instance($config_map=array()) {
     $CI = (object) array(
         'config' => (object) array(
@@ -14,7 +13,23 @@ function get_mock_codeigniter_instance($config_map=array()) {
             'save' => function($data) {
                 return $data;
             }
-        )
+        ),
+        'users' => (object) array(
+            'get_by_email' => function($data) {
+                return array('user_id' => rand());
+            },
+            'db' => (object) array(
+                'insert' => function() {
+                    return true;
+                }
+            ),
+            'save_books' => function() {
+                return true;
+            }
+        ),
+        'CSV_ROWS' => array('fullname','email','huid','in_index','relationship'),
+        'RELATIONSHIPS' => array('author','editor','commentator','reviewer','reader')
+
     );
     return $CI;
 }
@@ -29,7 +44,7 @@ class HarvardsettingsTest extends TestCase {
             ->getMock();
         $plugin->method('get_codeigniter_instance')->will($this->returnValue($codeigniter_instance));
         $plugin->method('get_base_url')->willReturn($base_url);
-    
+
         $reflectedClass = new ReflectionClass('Harvardsettings');
         $constructor = $reflectedClass->getConstructor();
         $constructor->invoke($plugin, $data);
@@ -44,6 +59,7 @@ class HarvardsettingsTest extends TestCase {
                 'description' => 'A long time ago in a galaxy far, far away....'
             )
         );
+
         $mock_codeigniter_instance = get_mock_codeigniter_instance();
         $plugin = $this->create_mock_plugin_instance($mock_codeigniter_instance, $data);
         $this->assertEquals($mock_codeigniter_instance, $plugin->CI);
@@ -84,7 +100,7 @@ class HarvardsettingsTest extends TestCase {
         foreach($tests as $test) {
             list($subdomain_is_on, $expected_value) = $test;
             $mock_codeigniter_instance = get_mock_codeigniter_instance();
-            $data = array('book' => 
+            $data = array('book' =>
                 (object) array('subdomain_is_on' => $subdomain_is_on)
             );
             $plugin = $this->create_mock_plugin_instance($mock_codeigniter_instance, $data);
@@ -98,7 +114,7 @@ class HarvardsettingsTest extends TestCase {
 
         $config_map = array('is_https' => true);
         $mock_codeigniter_instance = get_mock_codeigniter_instance($config_map);
-        $data = array('book' => 
+        $data = array('book' =>
             (object) array(
                 'slug' => 'awesomebook',
                 'subdomain_is_on' => true
@@ -106,7 +122,32 @@ class HarvardsettingsTest extends TestCase {
         );
         $plugin = $this->create_mock_plugin_instance($mock_codeigniter_instance, $data);
 
-        $expected_subdomain_url = "https://".$data['book']->slug.".".$domain.'/';       
+        $expected_subdomain_url = "https://".$data['book']->slug.".".$domain.'/';
         $this->assertEquals($expected_url, $plugin->get_subdomain_url());
     }
+    
+    public function test_build_curl_string() {
+        $test_array = array(
+            array(
+                'email' => '',
+                'huid' => 11
+            ),
+            array(
+                'email' => 'fake1@fake.org',
+                'huid' => 12
+            )
+        );
+        $data = array(
+            'book' => (object) array(
+                'title' => "The most awesomest book title ever!",
+                'description' => 'A long time ago in a galaxy far, far away....',
+                'book_id' => 1
+            )
+        );
+        $mock_codeigniter_instance = get_mock_codeigniter_instance();
+        $plugin = $this->create_mock_plugin_instance($mock_codeigniter_instance, $data);
+        $import = $plugin->build_curl_string($test_array);
+        $this->assertEquals('/people?huids=11,&filter=name,email', $import);
+    }
+
 }


### PR DESCRIPTION
This pull request adds the ability to use the huid of a user to to look up their name and email via the Person Data Service.
- It will only engage the PDS if the huid is provided, and email is not.
- Report back the number of users that were failed to be added to the book.
- Refactor the `import_users` method.