### PR TITLE
Upload improvements

### DIFF
--- a/harvardsettings_pi.php
+++ b/harvardsettings_pi.php
@@ -401,7 +401,7 @@ class Harvardsettings {
         );
         $output = json_decode(curl_exec($c));
         curl_close($c);
-        $return_str = 'placeholder'
+        $return_str = 'placeholder';
         if (isset($output->message)) {
             if ($output->message === "No valid key, huid, netid, or email found.") {
                 return $return_str;

--- a/harvardsettings_pi.php
+++ b/harvardsettings_pi.php
@@ -369,9 +369,10 @@ class Harvardsettings {
             else {
                 $name = $person->names[0]->firstName . " " . $person->names[0]->lastName;
             }
+            $email = $person->loginName ? $person->loginName : $person->emails[0]->email;
             $return_obj->$id = (object) array(
                 'name' => $name,
-                'email' => $person->loginName
+                'email' => $email
             );    
         }
         $accessing_user = $this->CI->data['login']->email." (".$this->CI->data['login']->user_id.")";

--- a/harvardsettings_pi.php
+++ b/harvardsettings_pi.php
@@ -432,14 +432,6 @@ class Harvardsettings {
         return $curl_string . "&filter=name,email";
     }
     
-    // if email is missing: we must get it by using huid.
-    //// This also takes care of their name
-    // If email is provided, but name is missing, we must get the name using email
-    //// curl_string people?email=email&filter=name,email
-    //// you can use the full email
-    //// It doesn't appear that you can make a bulk request this way, so names will need to be handled individually
-    
-    
     public function download_template() {
         $template_data = array($this->CSV_ROWS);
         $f = fopen('php://output', 'w');


### PR DESCRIPTION
This PR resolves [ATGU-2716](https://jira.huit.harvard.edu/browse/ATGU-2716) and [ATGU-2717](https://jira.huit.harvard.edu/browse/ATGU-2717) by:

- When using the PDS to get user data, if the user's `loginName` is null, get the email from the first entry of the user's `emails` list
- If the email is provided, but the user's full name has not been, we now query the PDS using the provided email in an attempt to get the user's full name.

## Notes
- I didn't see a way to execute a bulk query of the PDS using emails to retrieve information. Those queries have to be executed individually per email as needed